### PR TITLE
Trim trailing newline from buildinfo.

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ func buildinfo() string {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return string(output)
+	return strings.TrimRight(string(output), "\r\n")
 }
 
 func exeName(module, goos string) string {


### PR DESCRIPTION
Before:

```
manifest hash: SHA256:5d012f4c48d58af50c1f2257c191aea064caca820888e1ed7d2c20d2d948ecc1 (go version go1.15.3 linux/amd64
)
```
After:

```
manifest hash: SHA256:5d012f4c48d58af50c1f2257c191aea064caca820888e1ed7d2c20d2d948ecc1 (go version go1.15.3 linux/amd64)
```

