### PR TITLE
Update dcrinstall for v1.6.0-rc3

### DIFF
--- a/decred-release/go.mod
+++ b/decred-release/go.mod
@@ -2,4 +2,4 @@ module decred.org/release/decred-release
 
 go 1.15
 
-require github.com/decred/decred-release v1.6.0-rc2.0.20201109192103-c592e157b07b
+require github.com/decred/decred-release v1.6.0-rc2.0.20201113202823-d6899044f6aa

--- a/decred-release/go.sum
+++ b/decred-release/go.sum
@@ -38,8 +38,8 @@ github.com/decred/dcrd/dcrutil/v3 v3.0.0/go.mod h1:iVsjcqVzLmYFGCZLet2H7Nq+7imV9
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/decred/dcrd/wire v1.4.0 h1:KmSo6eTQIvhXS0fLBQ/l7hG7QLcSJQKSwSyzSqJYDk0=
 github.com/decred/dcrd/wire v1.4.0/go.mod h1:WxC/0K+cCAnBh+SKsRjIX9YPgvrjhmE+6pZlel1G7Ro=
-github.com/decred/decred-release v1.6.0-rc2.0.20201109192103-c592e157b07b h1:uwAoiQ/VRcCNVLh7on7r72pPLE1pC956eLmUG6lu5Bo=
-github.com/decred/decred-release v1.6.0-rc2.0.20201109192103-c592e157b07b/go.mod h1:FjFxeh2vZLjXa6gB8Ax5BAHI/K4fx7Of+NMB75+PNig=
+github.com/decred/decred-release v1.6.0-rc2.0.20201113202823-d6899044f6aa h1:zwDmqpmUxV/1/fENtVwsXvcZiLk31PjI7z880On2iOg=
+github.com/decred/decred-release v1.6.0-rc2.0.20201113202823-d6899044f6aa/go.mod h1:FjFxeh2vZLjXa6gB8Ax5BAHI/K4fx7Of+NMB75+PNig=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=


### PR DESCRIPTION
This updates the source to build dcrinstall for the v1.6.0-rc3
release, and adds the proper linker flags to enable dcrinstall's
self-check on its own embedded version compared to what it discovered
in the latest file.