### PR TITLE
Use relative paths in faked manifest

### DIFF
--- a/fakelatest.sh
+++ b/fakelatest.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 
 find dist -name '*-manifest.txt' | perl -MDigest::SHA -lne \
-	'print Digest::SHA->new(256)->addfile($_)->hexdigest, "  file://$ENV{PWD}/$_"'
-find thirdparty -type f | perl -MDigest::SHA -MFile::Basename -ne '\
-	chomp;
+	'print Digest::SHA->new(256)->addfile($_)->hexdigest, "  file://$_"'
+find thirdparty -type f | perl -MDigest::SHA -lne '\
 	open (my $f, "<", $_);
 	chomp(my $url = <$f>);
 	local $/;
 	my $contents = <$f>;
 	my $sum = Digest::SHA->new(256)->add($contents)->hexdigest;
-	print "$sum  $url\n";'
+	print "$sum  $url";'


### PR DESCRIPTION
This makes the testing easier to perform on windows.

While here also clean up some parts of the final perl incantation.