### PR TITLE
Parse last item of 'go version' as native tuple

### DIFF
--- a/dcrinstall.sh
+++ b/dcrinstall.sh
@@ -6,6 +6,6 @@ TUPLE=$(go version | perl -lane 'print $F[-1] =~ s,/,-,r')
 DCRINSTALL=./bin/${TUPLE}/dcrinstall
 
 [ -x ${DCRINSTALL} ] || go run . -dist dcrinstall
-[ -f fake-latest ] || go run . -dist dcrinstall-manifests
+[ -s fake-latest ] || go run . -dist dcrinstall-manifests
 
 exec ${DCRINSTALL} -manifest file://fake-latest -skippgp "$@"

--- a/dcrinstall.sh
+++ b/dcrinstall.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TUPLE=$(go version | perl -lane 'print $F[3] =~ s,/,-,r')
+TUPLE=$(go version | perl -lane 'print $F[-1] =~ s,/,-,r')
 DCRINSTALL=./bin/${TUPLE}/dcrinstall
 
 [ -x ${DCRINSTALL} ] || go run . -dist dcrinstall


### PR DESCRIPTION
Development go versions include additional build metadata, which
shifts the os/arch after the 4th field.  Since it's always the last
one, just use that.