### PR TITLE
Skip dcrinstall-manifests distribution with -target

### DIFF
--- a/main.go
+++ b/main.go
@@ -577,6 +577,9 @@ type dcrinstallManifest struct {
 }
 
 func (d *dcrinstallManifest) fakedist(dist *dist) {
+	if *target != "" {
+		return
+	}
 	d.dist = dist
 	outpath := fmt.Sprintf("dist/dcrinstall-%s-manifests.txt", d.relver)
 	out, err := os.Create(outpath)


### PR DESCRIPTION
Manifests are not written for any of the real distributions when
-target is used, but the dcrinstall-manifests fake distribution was
erroring due to missing dependencies on those other manifest files
when run with an empty dist directory.