### PR TITLE
Enable PIE on several targets

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,15 @@ var targets = []tuple{
 	{"windows", "amd64"},
 }
 
+var pie = map[tuple]bool{
+	{"darwin", "amd64"}:  true,
+	{"darwin", "arm64"}:  true,
+	{"linux", "amd64"}:   true,
+	{"linux", "arm64"}:   true,
+	{"windows", "386"}:   true,
+	{"windows", "amd64"}: true,
+}
+
 type dist struct {
 	dist       string
 	relver     string
@@ -286,8 +295,12 @@ func readassetpath(builddir string, prog string) string {
 func build(tool, builddir, goos, arch, ldflags string) {
 	exe := exeName(tool, goos)
 	out := filepath.Join("..", "bin", goos+"-"+arch, exe)
+	buildmode := "-buildmode=exe"
+	if pie[tuple{goos, arch}] {
+		buildmode = "-buildmode=pie"
+	}
 	log.Printf("build: %s", out[3:]) // trim off leading "../"
-	gocmd(goos, arch, builddir, "build", "-trimpath", "-tags", tags, "-o", out, "-ldflags", ldflags, tool)
+	gocmd(goos, arch, builddir, "build", "-trimpath", "-tags", tags, "-o", out, "-ldflags", ldflags, buildmode, tool)
 }
 
 func gocmd(goos, arch, builddir string, args ...string) {


### PR DESCRIPTION
PIE provides additional hardening by loading the program code at
random offsets each execution, rather than all code being mapped to a
static memory location.  This complicates attacks such as ROP which
require jumping to known gadgets in the program text.

Other targets also support PIE, but it does not appear to be possible
to link the executable in a cross compile situation without the
platform's native linker.  This is the case for linux/386, linux/arm,
and freebsd/amd64.

As a consequence of producing a PIE, the Linux executables will now
link to the dynamic link editor (e.g. /lib64/ld-linux-x86-64.so.2 for
amd64), and will no longer run on distributions which do not provide
the link editor the expected path.  This is not expected to be a
common issue for most distributions, and for those that are affected
because of their reproducibility guarantees (e.g. NixOS), tooling is
available to patch the path to the dynamic link editor in the ELF
file.