### PR TITLE
Prepare v1.7.0-rc3

### DIFF
--- a/dcrdex/go.mod
+++ b/dcrdex/go.mod
@@ -3,6 +3,6 @@ module decred.org/release/dcrdex
 go 1.16
 
 require (
-	decred.org/dcrdex v0.4.0-rc2
-	decred.org/dcrdex-assets v0.4.0-rc2
+	decred.org/dcrdex v0.4.0-rc3
+	decred.org/dcrdex-assets v0.4.0-rc3
 )

--- a/dcrdex/go.sum
+++ b/dcrdex/go.sum
@@ -18,10 +18,10 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 decred.org/cspp/v2 v2.0.0-20211122173608-ee00e4952d5f/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
-decred.org/dcrdex v0.4.0-rc2 h1:bWXd+OOVtLR9w6fbQNZMV1u6VeMX6Eh3a1LBxNRXjjE=
-decred.org/dcrdex v0.4.0-rc2/go.mod h1:8tXM3igbHUkEu4YJd1q7Czwmfh9xf0oA3dSdrUi/Bqs=
-decred.org/dcrdex-assets v0.4.0-rc2 h1:M3XmglPEzH+kaW6jE7xJB/NiCJ5UCYHry9PyHNjW8kM=
-decred.org/dcrdex-assets v0.4.0-rc2/go.mod h1:8TML4Z40BuIp+Eyx5yiGGmhflOQgcWDqQTAmZxftNZo=
+decred.org/dcrdex v0.4.0-rc3 h1:OLsHzEgXFUOMlKXLYefhtW2o0X7dwSJYTHYRGlyhJ1g=
+decred.org/dcrdex v0.4.0-rc3/go.mod h1:8tXM3igbHUkEu4YJd1q7Czwmfh9xf0oA3dSdrUi/Bqs=
+decred.org/dcrdex-assets v0.4.0-rc3 h1:IhBq/Av+HC9X3DCnJZQG1/uRHfFYZ9iHVC72vb+BrcU=
+decred.org/dcrdex-assets v0.4.0-rc3/go.mod h1:8TML4Z40BuIp+Eyx5yiGGmhflOQgcWDqQTAmZxftNZo=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb h1:vio6o+nzszBrdj2Yi3/gifDa5ocfy49A9SqYPlbUjXo=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb/go.mod h1:rbFJaCuXCfDhYoI5ZdeZr8TmF4A4Sb1zE7jQAwtaFMo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/dcrwallet/go.mod
+++ b/dcrwallet/go.mod
@@ -2,4 +2,4 @@ module decred.org/release/dcrwallet
 
 go 1.16
 
-require decred.org/dcrwallet/v2 v2.0.0-rc2
+require decred.org/dcrwallet/v2 v2.0.0-rc3

--- a/dcrwallet/go.sum
+++ b/dcrwallet/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-decred.org/cspp/v2 v2.0.0-20211207170141-a6b5f958a91f h1:UOIoro9DWT3DnIufGVRmIaOqsx36lV8+B3nqW33abRg=
-decred.org/cspp/v2 v2.0.0-20211207170141-a6b5f958a91f/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
-decred.org/dcrwallet/v2 v2.0.0-rc2 h1:LktB/7FtwsrwbKMP5hmVmSu1Ib8OGyGDuFxHHaTYNjk=
-decred.org/dcrwallet/v2 v2.0.0-rc2/go.mod h1:IOIVwOFCpA1Xhqz4Xo26IaD5qZN01EZRGyCJOZYnoc4=
+decred.org/cspp/v2 v2.0.0-20220117153402-4f26c92d52a3 h1:tG0oSis1lMSmLbBEnr21TmbmeULMtkZeiLAILWKedN0=
+decred.org/cspp/v2 v2.0.0-20220117153402-4f26c92d52a3/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
+decred.org/dcrwallet/v2 v2.0.0-rc3 h1:xxmZndkTheyfORD16nf8fUsevR3dBHdI8hhdAUFumZE=
+decred.org/dcrwallet/v2 v2.0.0-rc3/go.mod h1:NJnnnOrPISrCt5oxrkXgTu0feCnxcLUsbqsvdXtFVBI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=

--- a/main.go
+++ b/main.go
@@ -78,10 +78,10 @@ type manifestLine struct {
 type manifest []manifestLine
 
 const (
-	decredRelver = "v1.7.0-rc2"
-	dexcRelver   = "v0.4.0-rc2"
-	ldVersion    = "1.7.0-rc2"
-	prerelease   = "rc2"
+	decredRelver = "v1.7.0-rc3"
+	dexcRelver   = "v0.4.0-rc3"
+	ldVersion    = "1.7.0-rc3"
+	prerelease   = "rc3"
 )
 
 var dists = []dist{{


### PR DESCRIPTION
Updates dcrwallet to release-v1.7.0-rc3 tag.

Updates dcrdex and dcrdex-assets to to v0.4.0-rc3 tags.