### PR TITLE
Prepare v1.7.3

### DIFF
--- a/dcrwallet/go.mod
+++ b/dcrwallet/go.mod
@@ -2,7 +2,7 @@ module decred.org/release/dcrwallet
 
 go 1.17
 
-require decred.org/dcrwallet/v2 v2.0.4
+require decred.org/dcrwallet/v2 v2.0.5
 
 require (
 	decred.org/cspp/v2 v2.0.0 // indirect

--- a/dcrwallet/go.sum
+++ b/dcrwallet/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 decred.org/cspp/v2 v2.0.0 h1:b4fZrElRufz30rYnBZ2shhC8AjNVTN4i6TMzDi+hk44=
 decred.org/cspp/v2 v2.0.0/go.mod h1:0shJWKTWY3LxZEWGxtbER1Y45+HVjC0WZtj4bctSzCI=
-decred.org/dcrwallet/v2 v2.0.4 h1:nCEdVPzSeo0uIViU+lL0iSKH2A1N1FIQZ/1PSaHha2w=
-decred.org/dcrwallet/v2 v2.0.4/go.mod h1:ZI8fegZzymMTLiqOYRYBI+ZeWz3lyQ/FU70w3YiA50U=
+decred.org/dcrwallet/v2 v2.0.5 h1:JZHSAB3Am6C7GFkItWl7VkgaYx2XuYW1R2nT+HDPx74=
+decred.org/dcrwallet/v2 v2.0.5/go.mod h1:ZI8fegZzymMTLiqOYRYBI+ZeWz3lyQ/FU70w3YiA50U=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=


### PR DESCRIPTION
Updates dcrwallet to release-v1.7.3 tag (retag).