### PR TITLE
Remove -ldflags=buildid= workaround

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ var dists = []dist{{
 			goargs:   []string{"run", "readasset.go", "sample-politeiavoter.conf"},
 		},
 	},
-	ldflags: fmt.Sprintf(`-buildid= -s -w `+
+	ldflags: fmt.Sprintf(`-s -w `+
 		`-X github.com/decred/dcrd/internal/version.Version=%[1]s+release `+
 		`-X decred.org/dcrwallet/v2/version.BuildMetadata=release `+
 		`-X decred.org/dcrwallet/v2/version.PreRelease=%[2]s `+


### PR DESCRIPTION
This has been unnecessary since https://golang.org/cl/195318.