### PR TITLE
Add build flavor support, and build dexc with tray flavor

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,7 +149,13 @@ var dists = []dist{{
 	dist:   "dexc",
 	relver: dexcRelver,
 	tools: []buildtool{
-		{"decred.org/dcrdex/client/cmd/dexc", "./dcrdex", nil},
+		{"decred.org/dcrdex/client/cmd/dexc", "./dcrdex", []flavor{
+			{"tray", "windows", func(tags, ldflags string) (string, string) {
+				tags += ",systray"
+				ldflags += " -H=windowsgui"
+				return tags, ldflags
+			}},
+		}},
 		{"decred.org/dcrdex/client/cmd/dexcctl", "./dcrdex", nil},
 	},
 	ldflags: fmt.Sprintf(`-buildid= -s -w `+


### PR DESCRIPTION
[Add flavor support](https://github.com/decred/release/pull/90/commits/ac5759fb4c98c2481b37461f95872dd8d43dc565) 

Optional flavors may be added to a build target, resulting in
additional flavored executables being built and packaged.  A flavor
may be built for all operating systems, or limited to a particular
one.  The flavorbuild function returns a modified tags and ldflags
that the flavor is built with.

[Add dexc tray flavor](https://github.com/decred/release/pull/90/commits/886e603c6e9763330da49c05632d5eca3bed78d1) 

When built for Windows, dexc is built with the -H=windowsgui linker
flag and systray build tag, resulting in a Windows GUI application
(that lives in the taskbar) rather than a console executable.