### PR TITLE
Bump modules for v2.0.0 tag

### DIFF
--- a/dcrctl/go.mod
+++ b/dcrctl/go.mod
@@ -1,4 +1,4 @@
-module decred.org/release/dcrctl
+module decred.org/release/v2/dcrctl
 
 go 1.17
 

--- a/dcrd/go.mod
+++ b/dcrd/go.mod
@@ -1,4 +1,4 @@
-module decred.org/release/dcrd
+module decred.org/release/v2/dcrd
 
 go 1.19
 

--- a/dcrdex/go.mod
+++ b/dcrdex/go.mod
@@ -1,4 +1,4 @@
-module decred.org/release/dcrdex
+module decred.org/release/v2/dcrdex
 
 go 1.18
 

--- a/dcrlnd/go.mod
+++ b/dcrlnd/go.mod
@@ -1,4 +1,4 @@
-module decred.org/release/dcrlnd
+module decred.org/release/v2/dcrlnd
 
 go 1.20
 

--- a/dcrwallet/go.mod
+++ b/dcrwallet/go.mod
@@ -1,4 +1,4 @@
-module decred.org/release/dcrwallet
+module decred.org/release/v2/dcrwallet
 
 go 1.20
 

--- a/decred-release/go.mod
+++ b/decred-release/go.mod
@@ -1,4 +1,4 @@
-module decred.org/release/decred-release
+module decred.org/release/v2/decred-release
 
 go 1.17
 

--- a/politeia/go.mod
+++ b/politeia/go.mod
@@ -1,4 +1,4 @@
-module decred.org/release/politeia
+module decred.org/release/v2/politeia
 
 go 1.17
 


### PR DESCRIPTION
This may not be strictly necessary since we did not design the builder to contain any packages that other projects can import, but it seems like it would be good form that we use a v2 module suffix for the v2.0.0 release tag.

Builds still match bit for bit after this change.