### PR TITLE
Reenable windows/arm64 target

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ var targets = []tuple{
 	{"openbsd", "arm64"},
 	{"windows", "386"},
 	{"windows", "amd64"},
+	{"windows", "arm64"},
 }
 
 type dist struct {


### PR DESCRIPTION
This was removed due to a broken dexc build at the time, but the build succeeds now with newer bisonwallet releases when building with Go 1.24.